### PR TITLE
Derek task4 sprint2 bug fix

### DIFF
--- a/automation/ip-address-script/create-ip.ps1
+++ b/automation/ip-address-script/create-ip.ps1
@@ -11,9 +11,9 @@
 .PARAMETER IpName
     Suggested. Desired name of the IP address
 .PARAMETER IpVersion
-    Required. The type of IP, such as IPv4 or IPv6
+    Suggested. The type of IP, such as IPv4 or IPv6
 .PARAMETER IpMethod
-    Required. The allocation method, static or dynamic
+    Suggested. The allocation method, static or dynamic
 .NOTES
   Version:        2.0
   Author:         Derek Hendrick
@@ -50,6 +50,7 @@ param (
 )
 
 #Logs into the AZ account
+Clear-AzContext -Force 
 $Credential = Get-Credential
 Connect-AzAccount -Credential $Credential -Tenant $TenantId -ServicePrincipal
 
@@ -70,7 +71,7 @@ function CreateNewRG {
 
 #if errorVariable is notPresent VNet will not be created, and will prompt user 
 #to create a new resource group
-while ($notPresent) {
+if ($notPresent) {
   Write-Output "Existing resource group not found, creating new"
   CreateNewRG
   # Get existing resource group
@@ -107,3 +108,6 @@ if ($IpMethod){
 
 #deploying IP address
 New-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName -TemplateFile $FilePath -TemplateParameterObject $IpParameters
+
+#Clearing the account after
+Clear-AzContext -Force 

--- a/automation/ip-address-script/create-ip.ps1
+++ b/automation/ip-address-script/create-ip.ps1
@@ -18,6 +18,8 @@
     Suggested. The type of IP, such as IPv4 or IPv6
 .PARAMETER IpMethod
     Suggested. The allocation method, static or dynamic
+.PARAMETER ResourceLocation
+    Suggested. The location of the resource, such as westus2, if the resource group does not exist.
 .NOTES
   Version:        2.0
   Author:         Derek Hendrick
@@ -40,11 +42,11 @@ param (
     [string]
     $ResourceGroupName,
 
-    [Parameter(Mandatory=$False, HelpMessage='The service principal ID')]
+    [Parameter(Mandatory=$True, HelpMessage='The service principal ID')]
     [string]
     $ServicePrincipalId,
 
-    [Parameter(Mandatory=$False, HelpMessage='The service principal password')]
+    [Parameter(Mandatory=$True, HelpMessage='The service principal password')]
     [string]
     $ServicePrincipalPassword,
 
@@ -58,7 +60,11 @@ param (
 
     [Parameter(Mandatory=$False, HelpMessage='The allocation method, static or dynamic.')]
     [string]
-    $IpMethod
+    $IpMethod,
+
+    [Parameter(Mandatory=$False, HelpMessage='The location of the resource.')]
+    [string]
+    $ResourceLocation
 )
 
 #Clears all prior sign ins
@@ -82,7 +88,7 @@ function CreateNewRG {
     [string]
     $Location
   )
-  New-AzResourceGroup -Name $ResourceGroupName -Location $Location
+  New-AzResourceGroup -Name $ResourceGroupName -Location $ResourceLocation
 }
 
 #if errorVariable is notPresent VNet will not be created, and will prompt user 

--- a/automation/ip-address-script/create-ip.ps1
+++ b/automation/ip-address-script/create-ip.ps1
@@ -8,6 +8,10 @@
     Required. A tenant ID
 .PARAMETER ResourceGroupName
     Required. Name of existing Resource group
+.PARAMETER ServicePrincipalId
+    Required. ID for the service principal
+.PARAMETER ServicePrincipalPassword
+    Required. Password for the service principal
 .PARAMETER IpName
     Suggested. Desired name of the IP address
 .PARAMETER IpVersion
@@ -35,6 +39,14 @@ param (
     [Parameter(Mandatory=$True, HelpMessage='The name of the resource group this is being added to.')]
     [string]
     $ResourceGroupName,
+
+    [Parameter(Mandatory=$False, HelpMessage='The service principal ID')]
+    [string]
+    $ServicePrincipalId,
+
+    [Parameter(Mandatory=$False, HelpMessage='The service principal password')]
+    [string]
+    $ServicePrincipalPassword,
 
     [Parameter(Mandatory=$False, HelpMessage='The name of the IP address.')]
     [string]

--- a/automation/ip-address-script/create-ip.ps1
+++ b/automation/ip-address-script/create-ip.ps1
@@ -49,10 +49,14 @@ param (
     $IpMethod
 )
 
-#Logs into the AZ account
+#Clears all prior sign ins
 Clear-AzContext -Force 
-$Credential = Get-Credential
-Connect-AzAccount -Credential $Credential -Tenant $TenantId -ServicePrincipal
+
+#Signs in the user to Azure with service principal credential
+Write-Host Signing in using service principal
+$securePassword = ConvertTo-SecureString -String $ServicePrincipalPassword -AsPlainText -Force;
+$Credential = New-Object -TypeName System.Management.Automation.PSCredential($ServicePrincipalId, $securePassword);
+Connect-AzAccount -Credential $Credential -Tenant $TenantId -ServicePrincipal -SubscriptionId $SubscriptionId
 
 # Get existing resource group
 $Location = Get-AzResourceGroup -Name $ResourceGroupName -ErrorVariable notPresent -ErrorAction SilentlyContinue


### PR DESCRIPTION
This fixes the ip creation process so no additional inputs are required if ran correctly. For example:

./create-ip.ps1 -Tenant #### -Subscription #### -ServicePrincipalId #### -ServicePrincipalPassword #### -ResourceGroupName nsc-rg-dev-usw2-tuesday -IpName thisTestIpCanBeDeleted